### PR TITLE
Support more valid time zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.1 - 2022-05-11
+### Fixed
+- Support timezones that don't contain a `/` and are not `UTC` (e.g. `Zulu` or `CET`)
+
 ## 1.0.0 - 2019-11-27
 ### Added
 - Open-source the project.

--- a/expression.go
+++ b/expression.go
@@ -197,12 +197,12 @@ func Parse(raw string) (exp Expression, err error) {
 		chunks = chunks[1:]
 	}
 
-	// If there is still a chunk in the stack at this point, and that it is
-	// either UTC or contains a slash, it must be a timezone.
-	if len(chunks) != 0 && (chunks[0] == "UTC" || strings.Contains(chunks[0], "/")) {
+	// If there is still a chunk in the stack at this point it must be a
+	// timezone.
+	if len(chunks) != 0 {
 		exp.timezone, err = time.LoadLocation(chunks[0])
 		if err != nil {
-			return exp, fmt.Errorf(`parsing timezone: %w`, err)
+			return exp, fmt.Errorf("invalid chunk %s", chunks[0])
 		}
 
 		chunks = chunks[1:]

--- a/expression_test.go
+++ b/expression_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 // Those are the values used in the tests.
-var EuropeParis *time.Location
+var EuropeParis, Zulu *time.Location
 
 func init() {
 	EuropeParis, _ = time.LoadLocation("Europe/Paris")
+	Zulu, _ = time.LoadLocation("Zulu")
 }
 
 func TestParse(t *testing.T) {
@@ -105,6 +106,16 @@ func TestParse(t *testing.T) {
 			seconds:  []component{{From: 5}},
 			timezone: time.UTC,
 		}},
+		{name: "Zulu timezone", in: "Mon 2006-01-02 15:04:05 Zulu", out: Expression{
+			weekdays: []weekdayComponent{{From: 1}},
+			years:    []component{{From: 2006}},
+			months:   []component{{From: 1}},
+			days:     []component{{From: 2}},
+			hours:    []component{{From: 15}},
+			minutes:  []component{{From: 4}},
+			seconds:  []component{{From: 5}},
+			timezone: Zulu,
+		}},
 		{name: "date only", in: "2006-01-02", out: Expression{
 			weekdays: defaultWeekdays,
 			years:    []component{{From: 2006}},
@@ -138,6 +149,9 @@ func TestParse(t *testing.T) {
 		{name: "empty expression", in: "", err: true},
 		{name: "not an expression", in: "les sanglots longs des violons de l'automne", err: true},
 		{name: "timezone only", in: "Europe/Paris", err: true},
+		{name: "invalid timezone", in: "Mon 2006-01-02 15:04:05 hello", err: true},
+		{name: "too many chunks", in: "Mon 2006-01-02 15:04:05 UTC hello", err: true},
+		{name: "chunk after timezone", in: "Mon 15:04:05 UTC hello", err: true},
 	})
 }
 


### PR DESCRIPTION
Supported time zones were limited to either "UTC" or those containing a
"/" like "Europe/Paris". However, time zones such as "CET" or "Zulu" are
also valid and are now supported.